### PR TITLE
feat(slack): add support for 'team' option to restrict Slack login to…

### DIFF
--- a/packages/better-auth/src/social-providers/slack.ts
+++ b/packages/better-auth/src/social-providers/slack.ts
@@ -33,7 +33,8 @@ export interface SlackProfile extends Record<string, any> {
 	"https://slack.com/team_image_default": boolean;
 }
 
-export interface SlackOptions extends ProviderOptions<SlackProfile> {}
+export interface SlackOptions extends ProviderOptions<SlackProfile> {
+	team?: string; }
 
 export const slack = (options: SlackOptions) => {
 	return {
@@ -49,6 +50,11 @@ export const slack = (options: SlackOptions) => {
 			url.searchParams.set("scope", _scopes.join(" "));
 			url.searchParams.set("response_type", "code");
 			url.searchParams.set("client_id", options.clientId);
+			
+			if (options.team) {
+	                url.searchParams.set("team", options.team); 
+			}
+
 			url.searchParams.set("redirect_uri", options.redirectURI || redirectURI);
 			url.searchParams.set("state", state);
 			return url;


### PR DESCRIPTION
… specific workspace

This PR adds support for the `team` option in the Slack provider.

Changes:
- Added optional `team` property to `SlackOptions`
- Modified `createAuthorizationURL` to append `team` param when present

This allows developers to restrict sign-in to a specific Slack workspace, as mentioned in the docs but previously unimplemented.

Fixes #3752